### PR TITLE
Add asserts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,11 @@ EXTENSION = pg_stat_query_plans
 DATA = pg_stat_query_plans--1.0.sql
 PGFILEDESC = "pg_stat_query_plans - execution statistics and plans of SQL statements"
 
-# LDFLAGS_SL += $(filter -lm, $(LIBS))
 ifneq ($(shell uname), SunOS)
 LDFLAGS+=-Wl,--build-id
 endif
+
+PG_CPPFLAGS = -DPGQP_ASSERT_CHECKING
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_stat_query_plans/pg_stat_query_plans.conf
 REGRESS = pg_stat_query_plans_sql pg_stat_query_plans

--- a/README.MD
+++ b/README.MD
@@ -201,14 +201,14 @@ Table 3. pg_stat_query_plans_info_ya Columns
 pg_stat_query_plans functions
 -------------------------------
 
-### pg_stat_query_plans_reset_ya(userid Oid, dbid Oid, queryid bigint) returns void
+### pg_stat_query_plans_reset(userid Oid, dbid Oid, queryid bigint) returns void
 
  pg_stat_query_plans_reset_ya discards statistics (statements and execution plans) gathered so far by pg_stat_query_plans corresponding to the specified userid, dbid and queryid. If any of the parameters are not specified, the default value 0 is used for each of them and the statistics that match with other parameters will be reset. If no parameter is specified or all the specified parameters are 0, it will discard all statistics. If all statistics in the pg_stat_query_plans view are discarded, it will also reset the statistics in the pg_stat_query_plans_info view. By default, this function can only be executed by superusers. Access may be granted to others using GRANT.
 
 
-### pg_stat_query_plans_reset_minmax_ya() returns void
+### pg_stat_query_plans_reset_minmax() returns void
 
- Reset for all statements and execution plans statistics min_plan_time, max_plan_time, mean_plan_time, stddev_plan_time, min_exec_time, max_exec_time, ean_exec_time, stddev_exec_time to zero for pg_stat_staments_ya and min_exec_time, max_exec_time, ean_exec_time, stddev_exec_time to zero for pg_stat_staments_plans_ya. Could be usefull for measure planning and execution time deviations between statistics observations. 
+ Reset for all statements and execution plans statistics min_plan_time, max_plan_time, mean_plan_time, stddev_plan_time, min_exec_time, max_exec_time, ean_exec_time, stddev_exec_time to zero for pg_stat_staments_ya and min_exec_time, max_exec_time, ean_exec_time, stddev_exec_time to zero for pg_stat_query_plans. Could be usefull for measure planning and execution time deviations between statistics observations. 
 
 
 ### pg_stat_query_plans(showtext boolean) returns setof record
@@ -447,9 +447,9 @@ The data is stored in several structures:
 2. Hash table of query statistics
 3. Hash table of execution plan statistics
 
-When purge is performed, execution plans are sorted by usage (similar to pg_stat_query_plans). Remove FREE_PERCENT of the least used execution plans. During the deletion process, the reference counts in the query statistics and text storage are reduced. Then remove queries from the hash table with zero reference counts.
+When purge is performed, execution plans are sorted by usage (similar to pg_stat_query_plans). Remove PGQP_FREE_PERCENT of the least used execution plans. During the deletion process, the reference counts in the query statistics and text storage are reduced. Then remove queries from the hash table with zero reference counts.
 
-If the cause of cleanup was text memory area exhaustion, cleanup continues until FREE_PERCENT memory size will be freed.
+If the cause of cleanup was text memory area exhaustion, cleanup continues until PGQP_FREE_PERCENT memory size will be freed.
 
 If, after cleaning, a high watermark in the text storage area does not allow inserting new text, garbage collection is taking place in text storage (texts are moved, links to them are replaced).
 

--- a/pg_stat_query_plans.c
+++ b/pg_stat_query_plans.c
@@ -74,6 +74,7 @@
 #include "pg_stat_query_plans_common.h"
 #include "pg_stat_query_plans_parser.h"
 #include "pg_stat_query_plans_storage.h"
+#include "pg_stat_query_plans_assert.h"
 #include "utils/errcodes.h"
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
@@ -1311,7 +1312,7 @@ static void pg_stat_query_plans_plan_internal(FunctionCallInfo fcinfo,
 
     values[i++] = Int64GetDatumFast(entry->generation);
 
-    Assert(i == (api_version == PGQP_V1_0
+    pgqpAssert(i == (api_version == PGQP_V1_0
                      ? PG_STAT_QUERY_PLANS_PLAN_COLS_V1_0
                      : -1 /* fail if you forget to update this assert */));
 
@@ -1468,7 +1469,7 @@ static void pg_stat_query_plans_stat_internal(FunctionCallInfo fcinfo,
 
     values[i++] = Int64GetDatumFast(entry->generation);
 
-    Assert(i == (api_version == PGQP_V1_0
+    pgqpAssert(i == (api_version == PGQP_V1_0
                      ? PG_STAT_QUERY_PLANS_SQL_COLS_V1_0
                      : -1 /* fail if you forget to update this assert */));
 

--- a/pg_stat_query_plans.c
+++ b/pg_stat_query_plans.c
@@ -89,10 +89,10 @@ PG_FUNCTION_INFO_V1(pg_stat_query_plans_info);
 /*---- Global variables ----*/
 
 /* Current nesting depth of ExecutorRun+ProcessUtility calls */
-int exec_nested_level = 0;
+int pgqp_exec_nested_level = 0;
 
 /* Current nesting depth of planner calls */
-int plan_nested_level = 0;
+int pgqp_plan_nested_level = 0;
 
 const struct config_enum_entry track_options[] = {
     {"none", PGQP_TRACK_NONE, false},
@@ -196,7 +196,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 );
 #endif
 
-static int pgqp_add_counters_data(Counters *c, Datum values[0],
+static int pgqp_add_counters_data(pgqpCounters *c, Datum values[0],
                                   pgqpStoreKind start_kind);
 
 static void pg_stat_query_plans_stat_internal(FunctionCallInfo fcinfo,
@@ -409,7 +409,7 @@ static void pgqp_shmem_startup(void) {
     // pgqp->memory_lock =
     // &(GetNamedLWLockTranche("pg_stat_query_plans_memory"))->lock;
     pgqp->storage_offset = 0;
-    pgqp->cur_median_usage = ASSUMED_MEDIAN_INIT;
+    pgqp->cur_median_usage = PGQP_ASSUMED_MEDIAN_INIT;
     SpinLockInit(&pgqp->mutex);
     pgqp->stats.dealloc = 0;
     pgqp->stats.queries_wiped_out = 0;
@@ -477,7 +477,7 @@ pgqp_post_parse_analyze(ParseState *pstate, Query *query)
 
   /* Safety check... */
   if (!pgqp || !pgqp_queries || !pgqp_plans || !pgqp_texts ||
-      !pgqp_enabled(exec_nested_level))
+      !pgqp_enabled(pgqp_exec_nested_level))
     return;
 
 #if PG_VERSION_NUM < 140000
@@ -507,7 +507,7 @@ pgqp_post_parse_analyze(ParseState *pstate, Query *query)
   jstate.highest_extern_param_id = 0;
 
   /* Compute query ID and mark the Query node with it */
-  JumbleQuery(&jstate, query);
+  pgqpJumbleQuery(&jstate, query);
   query->queryId =
       DatumGetUInt64(hash_any_extended(jstate.jumble, jstate.jumble_len, 0));
 
@@ -563,7 +563,7 @@ static PlannedStmt *pgqp_planner(Query *parse, const char *query_string,
    * So testing the planner nesting level only is not enough to detect real
    * top level planner call.
    */
-  if (pgqp_enabled(plan_nested_level + exec_nested_level) &&
+  if (pgqp_enabled(pgqp_plan_nested_level + pgqp_exec_nested_level) &&
       pgqp_track_planning && query_string && parse->queryId != UINT64CONST(0)) {
     instr_time start;
     instr_time duration;
@@ -580,7 +580,7 @@ static PlannedStmt *pgqp_planner(Query *parse, const char *query_string,
     walusage_start = pgWalUsage;
     INSTR_TIME_SET_CURRENT(start);
 
-    plan_nested_level++;
+    pgqp_plan_nested_level++;
     PG_TRY();
     {
       if (prev_planner_hook)
@@ -591,7 +591,7 @@ static PlannedStmt *pgqp_planner(Query *parse, const char *query_string,
             standard_planner(parse, query_string, cursorOptions, boundParams);
     }
     PG_FINALLY();
-    { plan_nested_level--; }
+    { pgqp_plan_nested_level--; }
     PG_END_TRY();
 
     INSTR_TIME_SET_CURRENT(duration);
@@ -635,7 +635,7 @@ static void pgqp_ExecutorStart(QueryDesc *queryDesc, int eflags) {
    * counting of optimizable statements that are directly contained in
    * utility statements.
    */
-  if (pgqp_enabled(exec_nested_level) &&
+  if (pgqp_enabled(pgqp_exec_nested_level) &&
       queryDesc->plannedstmt->queryId != UINT64CONST(0)) {
     /*
      * Set up to track total elapsed time in ExecutorRun.  Make sure the
@@ -661,7 +661,7 @@ static void pgqp_ExecutorStart(QueryDesc *queryDesc, int eflags) {
  */
 static void pgqp_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
                              uint64 count, bool execute_once) {
-  exec_nested_level++;
+  pgqp_exec_nested_level++;
   PG_TRY();
   {
     if (prev_ExecutorRun)
@@ -672,12 +672,12 @@ static void pgqp_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
 #if PG_VERSION_NUM < 130000
   PG_CATCH();
   {
-    exec_nested_level--;
+    pgqp_exec_nested_level--;
     PG_RE_THROW();
   }
 #else
   PG_FINALLY();
-  { exec_nested_level--; }
+  { pgqp_exec_nested_level--; }
 #endif
   PG_END_TRY();
 }
@@ -686,7 +686,7 @@ static void pgqp_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
  * ExecutorFinish hook: all we need do is track nesting depth
  */
 static void pgqp_ExecutorFinish(QueryDesc *queryDesc) {
-  exec_nested_level++;
+  pgqp_exec_nested_level++;
   PG_TRY();
   {
     if (prev_ExecutorFinish)
@@ -697,12 +697,12 @@ static void pgqp_ExecutorFinish(QueryDesc *queryDesc) {
 #if PG_VERSION_NUM < 130000
   PG_CATCH();
   {
-    exec_nested_level--;
+    pgqp_exec_nested_level--;
     PG_RE_THROW();
   }
 #else
   PG_FINALLY();
-  { exec_nested_level--; }
+  { pgqp_exec_nested_level--; }
 #endif
   PG_END_TRY();
 }
@@ -718,7 +718,7 @@ static void pgqp_ExecutorEnd(QueryDesc *queryDesc) {
   MemoryContext oldctx;
 
   if (queryId != UINT64CONST(0) && queryDesc->totaltime &&
-      pgqp_enabled(exec_nested_level)) {
+      pgqp_enabled(pgqp_exec_nested_level)) {
     /*
      * Make sure stats accumulation is done.  (Note: it's okay if several
      * levels of hook all do this.)
@@ -817,7 +817,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
    * that user configured another extension to handle utility statements
    * only.
    */
-  if (pgqp_enabled(exec_nested_level) && pgqp_track_utility)
+  if (pgqp_enabled(pgqp_exec_nested_level) && pgqp_track_utility)
     pstmt->queryId = UINT64CONST(0);
 
   /*
@@ -834,7 +834,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
    *
    * Likewise, we don't track execution of DEALLOCATE.
    */
-  if (pgqp_track_utility && pgqp_enabled(exec_nested_level) &&
+  if (pgqp_track_utility && pgqp_enabled(pgqp_exec_nested_level) &&
       PGQP_HANDLED_UTILITY(parsetree)) {
     instr_time start;
     instr_time duration;
@@ -846,7 +846,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
     walusage_start = pgWalUsage;
     INSTR_TIME_SET_CURRENT(start);
 
-    exec_nested_level++;
+    pgqp_exec_nested_level++;
     PG_TRY();
     {
       if (prev_ProcessUtility)
@@ -857,7 +857,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
                                 params, queryEnv, dest, qc);
     }
     PG_FINALLY();
-    { exec_nested_level--; }
+    { pgqp_exec_nested_level--; }
     PG_END_TRY();
 
     INSTR_TIME_SET_CURRENT(duration);
@@ -925,7 +925,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
    *
    * Likewise, we don't track execution of DEALLOCATE.
    */
-  if (pgqp_track_utility && pgqp_enabled(exec_nested_level) &&
+  if (pgqp_track_utility && pgqp_enabled(pgqp_exec_nested_level) &&
       !IsA(parsetree, ExecuteStmt) && !IsA(parsetree, PrepareStmt) &&
       !IsA(parsetree, DeallocateStmt)) {
     instr_time start;
@@ -941,7 +941,7 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
     walusage_start = pgWalUsage;
 #endif
     INSTR_TIME_SET_CURRENT(start);
-    exec_nested_level++;
+    pgqp_exec_nested_level++;
     PG_TRY();
     {
       if (prev_ProcessUtility)
@@ -954,12 +954,12 @@ static void pgqp_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 #if PG_VERSION_NUM < 130000
     PG_CATCH();
     {
-      exec_nested_level--;
+      pgqp_exec_nested_level--;
       PG_RE_THROW();
     }
 #else
     PG_FINALLY();
-    { exec_nested_level--; }
+    { pgqp_exec_nested_level--; }
 #endif
     PG_END_TRY();
 
@@ -1105,7 +1105,7 @@ Datum pg_stat_query_plans_reset_minmax(PG_FUNCTION_ARGS) {
 #define PG_STAT_QUERY_PLANS_PLAN_COLS_V1_0 45
 #define PG_STAT_QUERY_PLANS_PLAN_COLS 45 /* maximum of above */
 
-static int pgqp_add_counters_data(Counters *c, Datum values[0],
+static int pgqp_add_counters_data(pgqpCounters *c, Datum values[0],
                                   pgqpStoreKind start_kind) {
   int i = 0;
   double stddev;
@@ -1244,8 +1244,8 @@ static void pg_stat_query_plans_plan_internal(FunctionCallInfo fcinfo,
     Datum values[PG_STAT_QUERY_PLANS_PLAN_COLS];
     bool nulls[PG_STAT_QUERY_PLANS_PLAN_COLS];
     int i = 0;
-    Counters tmp;
-    PlanCounters tmp_plan;
+    pgqpCounters tmp;
+    pgqpPlanCounters tmp_plan;
     char *tmp_str;
     volatile pgqpTextStorageEntry *s_query =
         (volatile pgqpTextStorageEntry *)entry->query_text;
@@ -1420,8 +1420,8 @@ static void pg_stat_query_plans_stat_internal(FunctionCallInfo fcinfo,
     Datum values[PG_STAT_QUERY_PLANS_SQL_COLS];
     bool nulls[PG_STAT_QUERY_PLANS_SQL_COLS];
     int i = 0;
-    Counters tmp;
-    Counters *tmpp;
+    pgqpCounters tmp;
+    pgqpCounters *tmpp;
     volatile pgqpTextStorageEntry *s =
         (volatile pgqpTextStorageEntry *)entry->query_text;
 
@@ -1460,7 +1460,7 @@ static void pg_stat_query_plans_stat_internal(FunctionCallInfo fcinfo,
 
     /* Skip entry if unexecuted (ie, it's a pending "sticky" entry) */
     tmpp = &tmp;
-    if (IS_STICKY(tmpp)) {
+    if (PGQP_IS_STICKY(tmpp)) {
       continue;
     }
 

--- a/pg_stat_query_plans_assert.h
+++ b/pg_stat_query_plans_assert.h
@@ -1,0 +1,29 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_stat_query_plans.c
+ *              Track statement planning and execution times as well as resource
+ *              usage across a whole database cluster.
+ *
+ * Assert definitions - use them for enable assertions only in pgqp extension
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PGQP_A
+#define PGQP_A
+
+# ifndef PGQP_ASSERT_CHECKING
+
+#define pgqpAssert(condition)       ((void)true)
+#define pgqpAssertMacro(condition)  ((void)true)
+
+# else
+
+#include <assert.h>
+#define pgqpAssert(p) assert(p)
+#define pgqpAssertMacro(p)  ((void) assert(p))
+
+# endif
+
+#endif

--- a/pg_stat_query_plans_common.h
+++ b/pg_stat_query_plans_common.h
@@ -31,6 +31,7 @@
 									!IsA(n, PrepareStmt) && \
 									!IsA(n, DeallocateStmt))
 
+
 /*
  * Extension version number, for supporting older extension versions' objects
  */

--- a/pg_stat_query_plans_parser.c
+++ b/pg_stat_query_plans_parser.c
@@ -19,6 +19,7 @@
 #endif
 
 #include "pg_stat_query_plans_parser.h"
+#include "pg_stat_query_plans_assert.h"
 
 #if PG_VERSION_NUM < 140000
 
@@ -76,8 +77,8 @@ void pgqpAppendJumble(pgqpJumbleState *jstate, const unsigned char *item,
  * of information).
  */
 void pgqpJumbleQuery(pgqpJumbleState *jstate, Query *query) {
-  Assert(IsA(query, Query));
-  Assert(query->utilityStmt == NULL);
+  pgqpAssert(IsA(query, Query));
+  pgqpAssert(query->utilityStmt == NULL);
 
   PGQP_APP_JUMB(query->commandType);
   /* resultRelation is usually predictable from commandType */
@@ -657,7 +658,7 @@ char *pgqp_gen_normquery(pgqpJumbleState *jstate, const char *query, int query_l
     len_to_wrt = off - last_off;
     len_to_wrt -= last_tok_len;
 
-    Assert(len_to_wrt >= 0);
+    pgqpAssert(len_to_wrt >= 0);
     memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
     n_quer_loc += len_to_wrt;
 
@@ -676,11 +677,11 @@ char *pgqp_gen_normquery(pgqpJumbleState *jstate, const char *query, int query_l
    */
   len_to_wrt = query_len - quer_loc;
 
-  Assert(len_to_wrt >= 0);
+  pgqpAssert(len_to_wrt >= 0);
   memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
   n_quer_loc += len_to_wrt;
 
-  Assert(n_quer_loc <= norm_query_buflen);
+  pgqpAssert(n_quer_loc <= norm_query_buflen);
   norm_query[n_quer_loc] = '\0';
 
   *query_len_p = n_quer_loc;
@@ -753,7 +754,7 @@ void pgqp_fill_in_constant_lengths(pgqpJumbleState *jstate, const char *query,
     /* Adjust recorded location if we're dealing with partial string */
     loc -= query_loc;
 
-    Assert(loc >= 0);
+    pgqpAssert(loc >= 0);
 
     if (loc <= last_loc)
       continue; /* Duplicate constant, ignore */
@@ -870,7 +871,7 @@ char *pgqp_gen_normquery(JumbleState *jstate, const char *query, int query_loc,
     len_to_wrt = off - last_off;
     len_to_wrt -= last_tok_len;
 
-    Assert(len_to_wrt >= 0);
+    pgqpAssert(len_to_wrt >= 0);
     memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
     n_quer_loc += len_to_wrt;
 
@@ -889,11 +890,11 @@ char *pgqp_gen_normquery(JumbleState *jstate, const char *query, int query_loc,
    */
   len_to_wrt = query_len - quer_loc;
 
-  Assert(len_to_wrt >= 0);
+  pgqpAssert(len_to_wrt >= 0);
   memcpy(norm_query + n_quer_loc, query + quer_loc, len_to_wrt);
   n_quer_loc += len_to_wrt;
 
-  Assert(n_quer_loc <= norm_query_buflen);
+  pgqpAssert(n_quer_loc <= norm_query_buflen);
   norm_query[n_quer_loc] = '\0';
 
   *query_len_p = n_quer_loc;
@@ -960,7 +961,7 @@ void pgqp_fill_in_constant_lengths(JumbleState *jstate, const char *query,
     /* Adjust recorded location if we're dealing with partial string */
     loc -= query_loc;
 
-    Assert(loc >= 0);
+    pgqpAssert(loc >= 0);
 
     if (loc <= last_loc)
       continue; /* Duplicate constant, ignore */

--- a/pg_stat_query_plans_parser.h
+++ b/pg_stat_query_plans_parser.h
@@ -38,27 +38,27 @@ typedef struct pgqpJumbleState
 	int                     highest_extern_param_id;
 } pgqpJumbleState;
 
-void AppendJumble(pgqpJumbleState *jstate,
+void pgqpAppendJumble(pgqpJumbleState *jstate,
 						 const unsigned char *item, Size size);
-void JumbleQuery(pgqpJumbleState *jstate, Query *query);
-void JumbleRangeTable(pgqpJumbleState *jstate, List *rtable);
-void JumbleRowMarks(pgqpJumbleState *jstate, List *rowMarks);
-void JumbleExpr(pgqpJumbleState *jstate, Node *node);
-void RecordConstLocation(pgqpJumbleState *jstate, int location);
-char *gen_normquery(pgqpJumbleState *jstate, const char *query,
+void pgqpJumbleQuery(pgqpJumbleState *jstate, Query *query);
+void pgqpJumbleRangeTable(pgqpJumbleState *jstate, List *rtable);
+void pgqpJumbleRowMarks(pgqpJumbleState *jstate, List *rowMarks);
+void pgqpJumbleExpr(pgqpJumbleState *jstate, Node *node);
+void pgqpRecordConstLocation(pgqpJumbleState *jstate, int location);
+char *pgqp_gen_normquery(pgqpJumbleState *jstate, const char *query,
 					int query_loc, int *query_len_p);
-void fill_in_constant_lengths(pgqpJumbleState *jstate, const char *query,
+void pgqp_fill_in_constant_lengths(pgqpJumbleState *jstate, const char *query,
 							  int query_loc);
 
 #else
-char *gen_normquery(JumbleState *jstate, const char *query,
+char *pgqp_gen_normquery(JumbleState *jstate, const char *query,
 					int query_loc, int *query_len_p);
 
-void fill_in_constant_lengths(JumbleState *jstate, const char *query,
+void pgqp_fill_in_constant_lengths(JumbleState *jstate, const char *query,
 							  int query_loc);
 #endif
 
-int comp_location(const void *a, const void *b);
+int pgqp_comp_location(const void *a, const void *b);
 
 #endif
 

--- a/pg_stat_query_plans_storage.c
+++ b/pg_stat_query_plans_storage.c
@@ -71,7 +71,7 @@ char *get_decoded_text(volatile pgqpTextStorageEntry *s) {
 
   Assert(s);
   Assert(s->text_len >= 0);
-  Assert(s->text_offset + s->text_len) < pgqp_storage_memory;
+  Assert(s->text_offset + s->text_len < pgqp_storage_memory);
 
   if (s->text_encoding == PGQP_PLAINTEXT)
     return SHMEM_TEXT_PTR(s->text_offset);

--- a/pg_stat_query_plans_storage.c
+++ b/pg_stat_query_plans_storage.c
@@ -220,6 +220,7 @@ void pgqp_remove_text(pgqpTextStorageEntry *entry) {
     if (entry->usage_count == 0) {
       volatile pgqpSharedState *s = (volatile pgqpSharedState *)pgqp;
       /* mark string as empty */
+      Assert(entry->text_offset >=0 && entry->text_offset < pgqp_storage_memory);
       strncpy(SHMEM_TEXT_PTR(entry->text_offset), "", 1);
       /* remove item from hash table */
       hash_search(pgqp_texts, &entry->text_key, HASH_REMOVE, NULL);

--- a/pg_stat_query_plans_storage.h
+++ b/pg_stat_query_plans_storage.h
@@ -35,7 +35,7 @@ void pgqp_entry_reset(Oid userid, Oid dbid, uint64 queryid);
 
 /* methods not used anywhere except unit testing */
 
-bool need_gc(bool already_started, int64 queries_size, int64 plans_size);
+bool pgqp_need_gc(bool already_started, int64 queries_size, int64 plans_size);
 
 void pgqp_dealloc(void);
 

--- a/tests/queryanalyze/queryparser.c
+++ b/tests/queryanalyze/queryparser.c
@@ -676,7 +676,7 @@ int main(int argc, char **argv)
 	lSize = ftell( fp );
 	rewind( fp );
 
-	Assert(lSize < BUFSIZE);
+	pgqpAssert(lSize < BUFSIZE);
 
 	if (fread( line , lSize, 1 , fp) == 0)
 		return 1;

--- a/tests/unit/check_pgss_store.c
+++ b/tests/unit/check_pgss_store.c
@@ -85,7 +85,7 @@ START_TEST(test_pgqp_alloc)
 	key.toplevel = true;
 	entry = pgqp_query_alloc(&key, false, 1);
 	ck_assert(entry);
-	ck_assert(entry->counters.usage == USAGE_INIT);
+	ck_assert(entry->counters.usage == PGQP_USAGE_INIT);
 	ck_assert(entry->plans_count == 0);
 	ck_assert(entry->generation == 1);
 	key.queryid = 4;
@@ -107,7 +107,7 @@ START_TEST(test_pgqp_alloc)
 	plan_key.planid = 1;
 	plan_entry = pgqp_plan_alloc(&plan_key, false, 3);
 	ck_assert(plan_entry);
-	ck_assert(plan_entry->counters.usage == USAGE_INIT);
+	ck_assert(plan_entry->counters.usage == PGQP_USAGE_INIT);
 	ck_assert(plan_entry->generation == 3);
 	plan_key.queryid = 2;
 	plan_entry = pgqp_plan_alloc(&plan_key, true, 4);
@@ -218,8 +218,8 @@ END_TEST
 
 START_TEST(test_need_gc)
 {
-	ck_assert(need_gc(false, 0, 0) == false);
-	ck_assert(need_gc(false, 100*1024*1024, 0) == true);
+	ck_assert(pgqp_need_gc(false, 0, 0) == false);
+	ck_assert(pgqp_need_gc(false, 100*1024*1024, 0) == true);
 }
 END_TEST
 


### PR DESCRIPTION
Here I made two changes: 

1. Renamed object names - some of them had the same names as pg_stat_statements objects, which could cause confusion about which object I was actually using. 

3. Added assertions to the code in pg_stat_query_plans_storage.c - only in heavy methods. It is better to let the program crash with an assertion than to write to random memory areas.