### PR TITLE
Allocate proper compression buffer

### DIFF
--- a/pg_stat_query_plans_storage.c
+++ b/pg_stat_query_plans_storage.c
@@ -149,7 +149,7 @@ pgqpTextStorageEntry *pgqp_store_text(const char *data, pgqpTextsKind kind,
       char *compressed_dst;
       int len;
       entry->origin_text_len = strlen(data) + 1;
-      compressed_dst = palloc(entry->origin_text_len);
+      compressed_dst = palloc(PGLZ_MAX_OUTPUT(entry->origin_text_len));
       len = pglz_compress(data, entry->origin_text_len, compressed_dst,
                           PGLZ_strategy_default);
       if (len > max_size) {

--- a/tests/queryanalyze/queryparser.c
+++ b/tests/queryanalyze/queryparser.c
@@ -629,7 +629,7 @@ bool do_parse(char* query, char* (*output_fnc)(const void*) )
 	// printf("%s\n", plan_out->data);
 
 
-	compressed_dst = palloc(plan_out->len);
+	compressed_dst = palloc(PGLZ_MAX_OUTPUT(plan_out->len));
 	uncompressed_dst = palloc(plan_out->len);
     len = pglz_compress(plan_out->data,
                         plan_out->len,


### PR DESCRIPTION
pglz might overwrite trailing 4 bytes of compressed buffer. Accounting for thi unlikely situation requires usage of PGLZ_MAX_OUTPUT macro.