### PR TITLE
postgresql 18 support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends:
  postgresql-server-dev-14,
  postgresql-server-dev-15,
  postgresql-server-dev-16,
- postgresql-server-dev-17
+ postgresql-server-dev-17,
+ postgresql-server-dev-18
 Homepage: https://github.com/postgredients/pg_stat_query_plans
 #Vcs-Git: git://github.com:postgredients/pg_stat_query_plans
 #Vcs-Browser: https://github.com/postgredients/pg_stat_query_plans
@@ -87,6 +88,17 @@ Description: PostgreSQL extension to gather per-query executioon plan statistics
 Package: postgresql-17-pgqp-ya
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, postgresql-17
+Description: PostgreSQL extension to gather per-query executioon plan statistics.
+ Statistics gathered are the same as for original pg_stat_query_plans extension.
+ Difference is data stored per normalized execution plan, not query. Normalized
+ execution plan is derived from query execution plan after removing all unimportant
+ data such as cost and numeric values (quite similar to query normalization in
+ original pg_stat_query_plans). Query texts and plans are stored in memory and by
+ default packed by pg_lzcompress.
+
+Package: postgresql-18-pgqp-ya
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}, postgresql-18
 Description: PostgreSQL extension to gather per-query executioon plan statistics.
  Statistics gathered are the same as for original pg_stat_query_plans extension.
  Difference is data stored per normalized execution plan, not query. Normalized

--- a/debian/control.in
+++ b/debian/control.in
@@ -12,7 +12,8 @@ Build-Depends:
  postgresql-server-dev-14,
  postgresql-server-dev-15,
  postgresql-server-dev-16,
- postgresql-server-dev-17
+ postgresql-server-dev-17,
+ postgresql-server-dev-18
 Homepage: https://github.com/postgredients/pg_stat_query_plans
 #Vcs-Git: git://github.com:postgredients/pg_stat_query_plans
 #Vcs-Browser: https://github.com/postgredients/pg_stat_query_plans

--- a/pg_stat_query_plans.c
+++ b/pg_stat_query_plans.c
@@ -43,6 +43,9 @@
 #include "access/hash.h"
 #endif
 #include "commands/explain.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#endif
 #include "executor/instrument.h"
 #include "funcapi.h"
 #include "jit/jit.h"

--- a/pg_stat_query_plans_id.c
+++ b/pg_stat_query_plans_id.c
@@ -7,6 +7,9 @@
 #include "executor/execdesc.h"
 #include "nodes/execnodes.h"
 #include "commands/explain.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#endif
 #include "common/hashfn.h"
 #include "nodes/extensible.h"
 #include "parser/parsetree.h"

--- a/pg_stat_query_plans_storage.c
+++ b/pg_stat_query_plans_storage.c
@@ -10,6 +10,10 @@
 #include "access/hash.h"
 #endif
 #include "commands/explain.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#include "commands/explain_format.h"
+#endif
 #include "executor/instrument.h"
 #include "funcapi.h"
 #include "jit/jit.h"


### PR DESCRIPTION
Add pg18 support, control files and some new imports:
in pg18 some structures have been moved from explain.h to explain_state.h/explain_format.h