### PR TITLE
Remove normalized plan generation and fix JSON output

### DIFF
--- a/expected/cursors.out
+++ b/expected/cursors.out
@@ -16,9 +16,9 @@ CLOSE cursor_stats_1;
 DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2;
 CLOSE cursor_stats_1;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
-     2 |    2 | SELECT 1;
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
+     2 |    2 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 1;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (2 rows)
 
@@ -48,9 +48,9 @@ CLOSE cursor_stats_1;
 CLOSE cursor_stats_2;
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
- calls | rows |                        query                         
--------+------+------------------------------------------------------
-     2 |    2 | SELECT 2;
+ calls | rows |                         query                         
+-------+------+-------------------------------------------------------
+     2 |    2 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 2;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (2 rows)
 

--- a/expected/level_tracking.out
+++ b/expected/level_tracking.out
@@ -187,23 +187,23 @@ EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                            query                             
-----------+-------+--------------------------------------------------------------
- f        |     1 | DELETE FROM stats_track_tab;
- f        |     1 | INSERT INTO stats_track_tab VALUES ((1));
- f        |     1 | MERGE INTO stats_track_tab                                  +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id+
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                       +
+ toplevel | calls |                               query                               
+----------+-------+-------------------------------------------------------------------
+ f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2);
+ f        |     1 | EXPLAIN (COSTS OFF) (TABLE test_table);
+ f        |     1 | EXPLAIN (COSTS OFF) (VALUES (1, 2));
+ f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab;
+ f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1));
+ f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                   +
+          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id     +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                            +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- f        |     1 | SELECT 1 UNION SELECT 2;
- f        |     1 | SELECT 1, 2);
- f        |     1 | SELECT 1;
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1 UNION SELECT 2;
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1;
+ f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab;
+ f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) VALUES (1);
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
- f        |     1 | TABLE stats_track_tab;
- f        |     1 | TABLE test_table);
- f        |     1 | UPDATE stats_track_tab SET x = 1 WHERE x = 1;
- f        |     1 | VALUES (1);
- f        |     1 | VALUES (1, 2));
 (12 rows)
 
 -- EXPLAIN - top-level tracking.
@@ -358,14 +358,14 @@ EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4\; EXPLAIN (COSTS OFF) (SELECT 
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                                           query                                           
-----------+-------+-------------------------------------------------------------------------------------------
- f        |     1 | (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
- f        |     1 | SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
- f        |     1 | SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
- f        |     1 | SELECT 1, 2, 3, 4);
- f        |     1 | SELECT 1, 2;
- f        |     1 | SELECT 1; EXPLAIN (COSTS OFF) SELECT 1, 2;
+ toplevel | calls |                                                     query                                                     
+----------+-------+---------------------------------------------------------------------------------------------------------------
+ f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
+ f        |     1 | EXPLAIN (COSTS OFF) (SELECT 1, 2, 3); EXPLAIN (COSTS OFF) (SELECT 1, 2, 3, 4);
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1, 2 UNION SELECT 3, 4; EXPLAIN (COSTS OFF) (SELECT 1, 2, 3) UNION SELECT 3, 4, 5;
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT 1, 2;
+ f        |     1 | EXPLAIN (COSTS OFF) SELECT 1; EXPLAIN (COSTS OFF) SELECT 1, 2;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (7 rows)
 
@@ -441,19 +441,19 @@ EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1))\; EXPLAIN (COSTS OF
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                                                   query                                                    
-----------+-------+------------------------------------------------------------------------------------------------------------
- f        |     1 | DELETE FROM stats_track_tab WHERE x = 1;
- f        |     1 | DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
- f        |     1 | INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
- f        |     1 | INSERT INTO stats_track_tab VALUES (1), (2);
+ toplevel | calls |                                                             query                                                              
+----------+-------+--------------------------------------------------------------------------------------------------------------------------------
+ f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab; EXPLAIN (COSTS OFF) DELETE FROM stats_track_tab WHERE x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
+ f        |     1 | EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES ((1)); EXPLAIN (COSTS OFF) INSERT INTO stats_track_tab VALUES (1), (2);
+ f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ f        |     1 | EXPLAIN (COSTS OFF) TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
+ f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
+ f        |     1 | EXPLAIN (COSTS OFF) VALUES (1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
- f        |     1 | TABLE stats_track_tab; EXPLAIN (COSTS OFF) (TABLE test_table);
- f        |     1 | TABLE test_table);
- f        |     1 | UPDATE stats_track_tab SET x = 1 WHERE x = 1; EXPLAIN (COSTS OFF) UPDATE stats_track_tab SET x = 1;
- f        |     1 | UPDATE stats_track_tab SET x = 1;
- f        |     1 | VALUES (1); EXPLAIN (COSTS OFF) (VALUES (1, 2));
- f        |     1 | VALUES (1, 2));
 (11 rows)
 
 SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
@@ -486,11 +486,14 @@ SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
  toplevel | calls |                                           query                                           
 ----------+-------+-------------------------------------------------------------------------------------------
- f        |     1 | MERGE INTO stats_track_tab                                                               +
+ f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                           +
           |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
           |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
- f        |     1 | SELECT 1, 2, 3, 4, 5;
+ f        |     1 | EXPLAIN (COSTS OFF) MERGE INTO stats_track_tab                                           +
+          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                             +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                    +
+          |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id); EXPLAIN (COSTS OFF) SELECT 1, 2, 3, 4, 5;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (3 rows)
 
@@ -699,19 +702,19 @@ EXPLAIN (COSTS OFF) WITH a AS (select 4) SELECT 1 UNION SELECT 2;
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                               query                                
-----------+-------+--------------------------------------------------------------------
- t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
- f        |     1 | WITH a AS (SELECT 4) (SELECT 1, 2));
- f        |     1 | WITH a AS (SELECT 4) DELETE FROM stats_track_tab;
- f        |     1 | WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1));
- f        |     1 | WITH a AS (SELECT 4) MERGE INTO stats_track_tab                   +
-          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id      +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                             +
+ toplevel | calls |                                         query                                          
+----------+-------+----------------------------------------------------------------------------------------
+ f        |     1 | EXPLAIN (COSTS OFF) (WITH a AS (SELECT 4) (SELECT 1, 2));
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) DELETE FROM stats_track_tab;
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) INSERT INTO stats_track_tab VALUES ((1));
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) MERGE INTO stats_track_tab                   +
+          |       |   USING (SELECT id FROM generate_series(1, 10) id) ON x = id                          +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                                 +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id);
- f        |     1 | WITH a AS (SELECT 4) SELECT 1;
- f        |     1 | WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1;
- f        |     1 | WITH a AS (select 4) SELECT 1 UNION SELECT 2;
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) SELECT 1;
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (SELECT 4) UPDATE stats_track_tab SET x = 1 WHERE x = 1;
+ f        |     1 | EXPLAIN (COSTS OFF) WITH a AS (select 4) SELECT 1 UNION SELECT 2;
+ t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (8 rows)
 
 -- EXPLAIN with CTEs - top-level tracking
@@ -797,24 +800,25 @@ SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (1 row)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100;
-           QUERY PLAN           
---------------------------------
- Result (actual rows=1 loops=1)
+            QUERY PLAN             
+-----------------------------------
+ Result (actual rows=1.00 loops=1)
 (1 row)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab;
-                     QUERY PLAN                      
------------------------------------------------------
- Seq Scan on stats_track_tab (actual rows=0 loops=1)
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Seq Scan on stats_track_tab (actual rows=0.00 loops=1)
 (1 row)
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                        query                         
-----------+-------+------------------------------------------------------
- f        |     1 | SELECT * FROM stats_track_tab;
- f        |     1 | SELECT 100;
+ toplevel | calls |                                     query                                      
+----------+-------+--------------------------------------------------------------------------------
+ f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)            +
+          |       |   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab;
+ f        |     1 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (3 rows)
 
@@ -827,16 +831,16 @@ SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (1 row)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF) SELECT 100;
-           QUERY PLAN           
---------------------------------
- Result (actual rows=1 loops=1)
+            QUERY PLAN             
+-----------------------------------
+ Result (actual rows=1.00 loops=1)
 (1 row)
 
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, BUFFERS OFF)
   DECLARE foocur CURSOR FOR SELECT * FROM stats_track_tab;
-                     QUERY PLAN                      
------------------------------------------------------
- Seq Scan on stats_track_tab (actual rows=0 loops=1)
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Seq Scan on stats_track_tab (actual rows=0.00 loops=1)
 (1 row)
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
@@ -925,11 +929,11 @@ CREATE TEMPORARY TABLE pgss_ctas_1 AS SELECT 1;
 CREATE TEMPORARY TABLE pgss_ctas_2 AS EXECUTE test_prepare_pgss;
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                        query                         
-----------+-------+------------------------------------------------------
- f        |     1 | SELECT 1;
+ toplevel | calls |                            query                            
+----------+-------+-------------------------------------------------------------
+ f        |     1 | CREATE TEMPORARY TABLE pgss_ctas_1 AS SELECT 1;
+ f        |     1 | PREPARE test_prepare_pgss AS select generate_series(1, 10);
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
- f        |     1 | select generate_series(1, 10);
 (3 rows)
 
 -- CREATE TABLE AS, top-level tracking.
@@ -965,9 +969,9 @@ EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgss_explain_ctas AS SELECT 1;
 
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                        query                         
-----------+-------+------------------------------------------------------
- f        |     1 | SELECT 1;
+ toplevel | calls |                                   query                                   
+----------+-------+---------------------------------------------------------------------------
+ f        |     1 | EXPLAIN (COSTS OFF) CREATE TEMPORARY TABLE pgss_explain_ctas AS SELECT 1;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (2 rows)
 
@@ -1011,9 +1015,9 @@ CLOSE foocur;
 COMMIT;
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                        query                         
-----------+-------+------------------------------------------------------
- f        |     1 | SELECT * from stats_track_tab;
+ toplevel | calls |                          query                           
+----------+-------+----------------------------------------------------------
+ f        |     1 | DECLARE FOOCUR CURSOR FOR SELECT * from stats_track_tab;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (2 rows)
 
@@ -1068,17 +1072,17 @@ COPY (DELETE FROM stats_track_tab WHERE x = 2 RETURNING x) TO stdout;
 2
 SELECT toplevel, calls, query FROM pg_stat_query_plans
   ORDER BY query COLLATE "C";
- toplevel | calls |                                 query                                  
-----------+-------+------------------------------------------------------------------------
- f        |     1 | DELETE FROM stats_track_tab WHERE x = 2 RETURNING x) TO stdout;
- f        |     1 | INSERT INTO stats_track_tab (x) VALUES (1) RETURNING x) TO stdout;
- f        |     1 | MERGE INTO stats_track_tab USING (SELECT 1 id) ON x = id              +
-          |       |   WHEN MATCHED THEN UPDATE SET x = id                                 +
+ toplevel | calls |                                   query                                    
+----------+-------+----------------------------------------------------------------------------
+ f        |     1 | COPY (DELETE FROM stats_track_tab WHERE x = 2 RETURNING x) TO stdout;
+ f        |     1 | COPY (INSERT INTO stats_track_tab (x) VALUES (1) RETURNING x) TO stdout;
+ f        |     1 | COPY (MERGE INTO stats_track_tab USING (SELECT 1 id) ON x = id            +
+          |       |   WHEN MATCHED THEN UPDATE SET x = id                                     +
           |       |   WHEN NOT MATCHED THEN INSERT (x) VALUES (id) RETURNING x) TO stdout;
- f        |     1 | SELECT 1 UNION SELECT 2) TO stdout;
- f        |     1 | SELECT 1) TO stdout;
+ f        |     1 | COPY (SELECT 1 UNION SELECT 2) TO stdout;
+ f        |     1 | COPY (SELECT 1) TO stdout;
+ f        |     1 | COPY (UPDATE stats_track_tab SET x = 2 WHERE x = 1 RETURNING x) TO stdout;
  t        |     1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
- f        |     1 | UPDATE stats_track_tab SET x = 2 WHERE x = 1 RETURNING x) TO stdout;
 (7 rows)
 
 -- COPY - top-level tracking.

--- a/expected/planning.out
+++ b/expected/planning.out
@@ -63,20 +63,20 @@ SELECT plans, calls, rows, query FROM pg_stat_query_plans_sql
 -------+-------+------+---------------------------------------------------------------
      0 |     1 |    0 | ALTER TABLE stats_plan_test ADD COLUMN x int;
      0 |     1 |    0 | CREATE TABLE stats_plan_test ();
+     2 |     4 |    4 | PREPARE prep1 AS SELECT COUNT(*) FROM stats_plan_test;
      3 |     3 |    3 | SELECT $1
      0 |     1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
      1 |     0 |    0 | SELECT plans, calls, rows, query FROM pg_stat_query_plans_sql+
        |       |      |   WHERE query NOT LIKE $1 ORDER BY query COLLATE "C"
-(5 rows)
+(6 rows)
 
 -- for the prepared statement we expect at least one replan, but cache
 -- invalidations could force more
 SELECT plans >= 2 AND plans <= calls AS plans_ok, calls, rows, query FROM pg_stat_query_plans_sql
   WHERE query LIKE 'SELECT COUNT%' ORDER BY query COLLATE "C";
- plans_ok | calls | rows |                 query                 
-----------+-------+------+---------------------------------------
- t        |     4 |    4 | SELECT COUNT(*) FROM stats_plan_test;
-(1 row)
+ plans_ok | calls | rows | query 
+----------+-------+------+-------
+(0 rows)
 
 -- Cleanup
 DROP TABLE stats_plan_test;

--- a/expected/select.out
+++ b/expected/select.out
@@ -128,7 +128,7 @@ DEALLOCATE pgss_test;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
  calls | rows |                           query                            
 -------+------+------------------------------------------------------------
-     1 |    1 | SELECT $1, 'test' LIMIT 1;
+     1 |    1 | PREPARE pgss_test (int) AS SELECT $1, 'test' LIMIT 1;
      1 |    1 | SELECT ' ' || ' !' ;;   SELECT 1 + 4 ;;
      4 |    4 | SELECT 'hello'                                            +
        |      |   -- but this one will appear                             +

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -215,10 +215,10 @@ EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 7;
 (2 rows)
 
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
- calls | rows |                           query                            
--------+------+------------------------------------------------------------
-     2 |    0 | SELECT 1;
-     2 |    0 | SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 3;
+ calls | rows |                                     query                                      
+-------+------+--------------------------------------------------------------------------------
+     2 |    0 | EXPLAIN (costs off) SELECT 1;
+     2 |    0 | EXPLAIN (costs off) SELECT a FROM generate_series(1,10) AS tab(a) WHERE a = 3;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (3 rows)
 
@@ -315,13 +315,13 @@ COPY (UPDATE copy_stats SET b = b + 2 RETURNING *) TO STDOUT;
 COPY (DELETE FROM copy_stats WHERE a = 1 RETURNING *) TO STDOUT;
 1	4
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
- calls | rows |                            query                             
--------+------+--------------------------------------------------------------
-     1 |    1 | DELETE FROM copy_stats WHERE a = 1 RETURNING *) TO STDOUT;
-     2 |    2 | INSERT INTO copy_stats VALUES (1, 1) RETURNING *) TO STDOUT;
-     2 |    2 | SELECT 1) TO STDOUT;
+ calls | rows |                               query                                
+-------+------+--------------------------------------------------------------------
+     1 |    1 | COPY (DELETE FROM copy_stats WHERE a = 1 RETURNING *) TO STDOUT;
+     2 |    2 | COPY (INSERT INTO copy_stats VALUES (1, 1) RETURNING *) TO STDOUT;
+     2 |    2 | COPY (SELECT 1) TO STDOUT;
+     2 |    4 | COPY (UPDATE copy_stats SET b = b + 1 RETURNING *) TO STDOUT;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
-     2 |    4 | UPDATE copy_stats SET b = b + 1 RETURNING *) TO STDOUT;
 (5 rows)
 
 DROP TABLE copy_stats;
@@ -348,8 +348,9 @@ DROP TABLE ctas_stats_2;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
  calls | rows |                              query                               
 -------+------+------------------------------------------------------------------
-     2 |    2 | SELECT 1 AS a;
-     2 |    4 | SELECT a AS col1, 2::int AS col2                                +
+     2 |    2 | CREATE TABLE ctas_stats_1 AS SELECT 1 AS a;
+     2 |    4 | CREATE TABLE ctas_stats_2 AS                                    +
+       |      |   SELECT a AS col1, 2::int AS col2                              +
        |      |     FROM generate_series(1, 10) AS tab(a) WHERE a < 5 AND a > 2;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (3 rows)
@@ -448,7 +449,7 @@ DEALLOCATE PREPARE ALL;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
  calls | rows |                        query                         
 -------+------+------------------------------------------------------
-     2 |    2 | SELECT $1 AS a;
+     2 |    2 | PREPARE stat_select AS SELECT $1 AS a;
      1 |    1 | SELECT 1 as a;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (3 rows)
@@ -569,10 +570,10 @@ FETCH FORWARD ALL pgss_cursor;
 
 COMMIT;
 SELECT calls, rows, query FROM pg_stat_query_plans ORDER BY query COLLATE "C";
- calls | rows |                         query                          
--------+------+--------------------------------------------------------
-     1 |    7 | SELECT * FROM pgss_matv;
-     1 |   10 | SELECT a, 'ctas' b FROM generate_series(1, 10) a;
+ calls | rows |                                    query                                    
+-------+------+-----------------------------------------------------------------------------
+     1 |   10 | CREATE TABLE pgss_ctas AS SELECT a, 'ctas' b FROM generate_series(1, 10) a;
+     1 |    7 | DECLARE pgss_cursor CURSOR FOR SELECT * FROM pgss_matv;
      1 |   10 | SELECT generate_series(1, 10) c INTO pgss_select_into;
      1 |    1 | SELECT pg_stat_query_plans_reset() IS NOT NULL AS t;
 (4 rows)

--- a/pg_stat_query_plans_storage.c
+++ b/pg_stat_query_plans_storage.c
@@ -579,6 +579,17 @@ void pgqp_store(const char *query, uint64 planId, uint64 queryId,
         if (example_log_triggers)
           ExplainPrintTriggers(es, qd);
         ExplainEndOutput(es);
+
+	/* Remove last line break */
+        if (es->str->len > 0 && es->str->data[es->str->len - 1] == '\n')
+            es->str->data[--es->str->len] = '\0';
+
+        /* Fix JSON to output an object */
+        if (example_plan_format == EXPLAIN_FORMAT_JSON)
+        {
+            es->str->data[0] = '{';
+            es->str->data[es->str->len - 1] = '}';
+        }
       }
       PG_CATCH();
       {
@@ -589,29 +600,6 @@ void pgqp_store(const char *query, uint64 planId, uint64 queryId,
       /* Store plan text */
       plan_entry->example_plan =
           pgqp_store_text(es->str->data, PGQP_SQLPLAN, planId, queryId);
-      if (example_plan_format != EXPLAIN_FORMAT_TEXT)
-      {
-        es = NewExplainState();
-        es->verbose = example_log_verbose;
-        es->format = EXPLAIN_FORMAT_TEXT;
-        PG_TRY();
-        {
-          ExplainBeginOutput(es);
-          ExplainPrintPlan(es, qd);
-          if (example_log_triggers)
-            ExplainPrintTriggers(es, qd);
-          ExplainEndOutput(es);
-        }
-        PG_CATCH();
-        {
-          resetStringInfo(es->str);
-          appendStringInfo(es->str, "Failed to generate normalized plan ");
-        }
-        PG_END_TRY();
-      }
-      /* Store normalized plan as a text */
-      plan_entry->gen_plan =
-        pgqp_store_text(es->str->data, PGQP_GENSQLPLAN, planId, queryId);
 
 
       /* Increase plans counter for query */


### PR DESCRIPTION
Remove normalized plan generation since it create a huge performance penalties.

Fix generated JSON as it has been doing in auto_explain https://github.com/postgres/postgres/blob/master/contrib/auto_explain/auto_explain.c#L422

Fix tests for PG 18.1